### PR TITLE
Use neo-async instead async

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const fs = require('fs')
 const path = require('path')
-const async = require('async')
+const async = require('neo-async')
 
 function readlink (link, cb) {
   var result = '/'

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
     "node": ">=6"
   },
   "dependencies": {
-    "async": "^2.5.0"
+    "neo-async": "^2.6.0"
   }
 }


### PR DESCRIPTION
> Neo-Async is thought to be used as a drop-in replacement for Async, it almost fully covers its functionality and runs faster.

Hello! I'm author of PR tj/commander.js/pull/869. I use your package for read symbolic links. Everything works as well, but your package depends by very big `async` (2 MB). `neo-async` is smaller (~290 KB) and faster.

P.S. In the ideal we must use native `Promise` with `async/await`. I'll try to do it if my PR will not be accepted.